### PR TITLE
投稿編集ページの実装

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -38,6 +38,7 @@ textarea {
   font-family : "Arial", "Hiragino Kaku Gothic ProN";
   font-size : 13.3px;
   min-height: 200px;
+  display: block;
 }
 .button {
   width: fit-content;

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -39,6 +39,7 @@ textarea {
   font-size : 13.3px;
   min-height: 200px;
   display: block;
+  resize: vertical;
 }
 .button {
   width: fit-content;

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -34,6 +34,11 @@ hr {
 table {
   border-collapse: collapse;
 }
+textarea {
+  font-family : "Arial", "Hiragino Kaku Gothic ProN";
+  font-size : 13.3px;
+  min-height: 200px;
+}
 .button {
   width: fit-content;
   display: inline-block;
@@ -51,25 +56,6 @@ table {
   border: none !important;
   padding: 0 !important;
   height: auto !important;
-}
-.FlexTextarea {
-  position: relative;
-  font-size: 0.9rem;
-  line-height: 1.8;
-}
-.FlexTextarea__dummy {
-  overflow: hidden;
-  visibility: hidden;
-  min-height: 80px;
-  white-space: pre-wrap;
-}
-.FlexTextarea__textarea {
-  position: absolute;
-  top: 0;
-  left: 0;
-  overflow: hidden;
-  height: 100%;
-  resize: none;
 }
 .hover-textdecoration:hover {
   text-decoration: underline;

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -45,8 +45,8 @@ class PostsController < ApplicationController
       flash[:notice] = "投稿を編集しました。"
       redirect_to post_path(@post)
     else
-      flash.now[:notice] = "投稿の編集に失敗しました。"
-      render edit_post_path(@post)
+      flash.now[:alert] = "投稿の編集に失敗しました。"
+      render :edit
     end
   end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -36,9 +36,18 @@ class PostsController < ApplicationController
   end
 
   def edit
+    @post = Post.find(params[:id])
   end
 
   def update
+    @post = Post.find(params[:id])
+    if @post.update(post_params)
+      flash[:notice] = "投稿を編集しました。"
+      redirect_to post_path(@post)
+    else
+      flash.now[:notice] = "投稿の編集に失敗しました。"
+      render edit_post_path(@post)
+    end
   end
 
   def destroy

--- a/app/javascript/packs/users/adjust_textarea.js
+++ b/app/javascript/packs/users/adjust_textarea.js
@@ -1,8 +1,0 @@
-function flexTextarea(el) {
-  const dummy = el.querySelector('.FlexTextarea__dummy')
-  el.querySelector('.FlexTextarea__textarea').addEventListener('input', e => {
-    dummy.textContent = e.target.value + '\u200b'
-  })
-}
-
-document.querySelectorAll('.FlexTextarea').forEach(flexTextarea)

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -549,6 +549,10 @@
               <%= f.submit "更新する", class: "hover-transform" %>
             </div>
           <% end %>
+          <hr class="hr-black"">
+          <div class="under-forms">
+            <p>投稿の編集ではなく、<%= link_to "投稿の削除", post_path(@post), class: "link-color-blue hover-textdecoration", method: :delete, data: { confirm: "投稿を削除してよろしいですか？" } %>をご希望ですか？</p>
+          </div>
         </div>
       </div>
     </div>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,2 +1,557 @@
-<h1>Posts#edit</h1>
-<p>Find me in app/views/posts/edit.html.erb</p>
+<% provide(:title, "#{@post.title}の編集") %>
+<% breadcrumb :posts_edit, @post %>
+<div class="whole">
+  <%= render "shared/flash_messages" %>
+  <div class="title">
+    <div class="title-container">
+      <%= breadcrumbs separator: " &rsaquo; " %> 
+      <h2>投稿編集</h2>
+    </div>
+  </div>
+  <div class="main">
+    <div class="main-container">
+      <h3 class="main-container-h3">編成情報を編集</h3>
+      <div class="forms-container">
+        <div class="forms">
+
+          <%= form_with model: @post do |f| %>
+          <%= render "shared/error_messages", obj: @post %>
+            <div class="form-line">
+              <div class="form-line-left">
+                <%= f.label :title, "タイトル" %>
+                <span class="length-supplement">(20文字まで)</span>
+              </div>
+              <div class="form-line-right">
+                <%= f.text_field :title, autofocus: true, required: true, maxlength: 20, placeholder: "編成タイトルを入力してください" %>
+                <div class="required-message">※ 入力必須です</div>
+              </div>
+            </div>
+            <div class="form-line">
+              <div class="form-line-left">
+                <%= f.label :weapon, "おすすめブキ" %>
+              </div>
+              <div class="form-line-right">
+                <%= f.select :weapon,
+                  grouped_options_for_select(Post::SELECT_WEAPON_OPTIONS, @post.weapon),
+                  { prompt: "ブキを選んでください" },
+                  required: true
+                %>
+              </div>
+            </div>
+            <div class="form-line">
+              <div class="form-line-left">
+                <%= f.label :battle, "おすすめバトル" %>
+              </div>
+              <div class="form-line-right">
+                <%= f.select :battle,
+                  ["ナワバリバトル", "ガチエリア", "ガチヤグラ", "ガチホコ", "ガチアサリ"],
+                  { prompt: "バトルを選んでください" },
+                  required: true
+                %>
+              </div>
+            </div>
+            <div class="form-line">
+              <div class="form-line-left">
+                <%= f.label :comment, "コメント" %>
+                <span class="length-supplement">(250文字まで)</span>
+              </div>
+              <div class="form-line-right">
+                <%= f.text_area :comment, maxlength: 250, placeholder: "編成のポイントやおすすめの立ち回りを入力してください" %>
+              </div>
+            </div>
+            <div class="form-line">
+              <div class="form-line-left">
+                <%= f.label :head_main, "アタマのメインパワー" %>
+              </div>
+              <div class="form-line-right">
+                <div class="radio-gear-power" id="radio-head-main">
+                  <%= f.radio_button :head_main, "1" %>
+                  <label for="post_head_main_1"></label>
+                  <%= f.radio_button :head_main, "2" %>
+                  <label for="post_head_main_2"></label>
+                  <%= f.radio_button :head_main, "3" %>
+                  <label for="post_head_main_3"></label>
+                  <%= f.radio_button :head_main, "4" %>
+                  <label for="post_head_main_4"></label>
+                  <%= f.radio_button :head_main, "5" %>
+                  <label for="post_head_main_5"></label>
+                  <%= f.radio_button :head_main, "6" %>
+                  <label for="post_head_main_6"></label>
+                  <%= f.radio_button :head_main, "7" %>
+                  <label for="post_head_main_7"></label>
+                  <%= f.radio_button :head_main, "8" %>
+                  <label for="post_head_main_8"></label>
+                  <%= f.radio_button :head_main, "9" %>
+                  <label for="post_head_main_9"></label>
+                  <%= f.radio_button :head_main, "10" %>
+                  <label for="post_head_main_10"></label>
+                  <%= f.radio_button :head_main, "11" %>
+                  <label for="post_head_main_11"></label>
+                  <%= f.radio_button :head_main, "12" %>
+                  <label for="post_head_main_12"></label>
+                  <%= f.radio_button :head_main, "13" %>
+                  <label for="post_head_main_13"></label>
+                  <%= f.radio_button :head_main, "14" %>
+                  <label for="post_head_main_14"></label>
+                  <%= f.radio_button :head_main, "15" %>
+                  <label for="post_head_main_15"></label>
+                  <%= f.radio_button :head_main, "16" %>
+                  <label for="post_head_main_16"></label>
+                  <%= f.radio_button :head_main, "17" %>
+                  <label for="post_head_main_17"></label>
+                  <%= f.radio_button :head_main, "18" %>
+                  <label for="post_head_main_18"></label>
+                </div>
+              </div>
+            </div>
+            <div class="form-line">
+              <div class="form-line-left">
+                <%= f.label :head_sub1, "アタマのサブパワー1" %>
+              </div>
+              <div class="form-line-right">
+                <div class="radio-gear-power" id="radio-head-sub1">
+                  <%= f.radio_button :head_sub1, "1" %>
+                  <label for="post_head_sub1_1"></label>
+                  <%= f.radio_button :head_sub1, "2" %>
+                  <label for="post_head_sub1_2"></label>
+                  <%= f.radio_button :head_sub1, "3" %>
+                  <label for="post_head_sub1_3"></label>
+                  <%= f.radio_button :head_sub1, "4" %>
+                  <label for="post_head_sub1_4"></label>
+                  <%= f.radio_button :head_sub1, "5" %>
+                  <label for="post_head_sub1_5"></label>
+                  <%= f.radio_button :head_sub1, "6" %>
+                  <label for="post_head_sub1_6"></label>
+                  <%= f.radio_button :head_sub1, "7" %>
+                  <label for="post_head_sub1_7"></label>
+                  <%= f.radio_button :head_sub1, "8" %>
+                  <label for="post_head_sub1_8"></label>
+                  <%= f.radio_button :head_sub1, "9" %>
+                  <label for="post_head_sub1_9"></label>
+                  <%= f.radio_button :head_sub1, "10" %>
+                  <label for="post_head_sub1_10"></label>
+                  <%= f.radio_button :head_sub1, "11" %>
+                  <label for="post_head_sub1_11"></label>
+                  <%= f.radio_button :head_sub1, "12" %>
+                  <label for="post_head_sub1_12"></label>
+                  <%= f.radio_button :head_sub1, "13" %>
+                  <label for="post_head_sub1_13"></label>
+                  <%= f.radio_button :head_sub1, "14" %>
+                  <label for="post_head_sub1_14"></label>
+                  <%= f.radio_button :head_sub1, "27" %>
+                  <label for="post_head_sub1_27"></label>
+                </div>
+              </div>
+            </div>
+            <div class="form-line">
+              <div class="form-line-left">
+                <%= f.label :head_sub2, "アタマのサブパワー2" %>
+              </div>
+              <div class="form-line-right">
+                <div class="radio-gear-power" id="radio-head-sub2">
+                  <%= f.radio_button :head_sub2, "1" %>
+                  <label for="post_head_sub2_1"></label>
+                  <%= f.radio_button :head_sub2, "2" %>
+                  <label for="post_head_sub2_2"></label>
+                  <%= f.radio_button :head_sub2, "3" %>
+                  <label for="post_head_sub2_3"></label>
+                  <%= f.radio_button :head_sub2, "4" %>
+                  <label for="post_head_sub2_4"></label>
+                  <%= f.radio_button :head_sub2, "5" %>
+                  <label for="post_head_sub2_5"></label>
+                  <%= f.radio_button :head_sub2, "6" %>
+                  <label for="post_head_sub2_6"></label>
+                  <%= f.radio_button :head_sub2, "7" %>
+                  <label for="post_head_sub2_7"></label>
+                  <%= f.radio_button :head_sub2, "8" %>
+                  <label for="post_head_sub2_8"></label>
+                  <%= f.radio_button :head_sub2, "9" %>
+                  <label for="post_head_sub2_9"></label>
+                  <%= f.radio_button :head_sub2, "10" %>
+                  <label for="post_head_sub2_10"></label>
+                  <%= f.radio_button :head_sub2, "11" %>
+                  <label for="post_head_sub2_11"></label>
+                  <%= f.radio_button :head_sub2, "12" %>
+                  <label for="post_head_sub2_12"></label>
+                  <%= f.radio_button :head_sub2, "13" %>
+                  <label for="post_head_sub2_13"></label>
+                  <%= f.radio_button :head_sub2, "14" %>
+                  <label for="post_head_sub2_14"></label>
+                  <%= f.radio_button :head_sub2, "27" %>
+                  <label for="post_head_sub2_27"></label>
+                </div>
+              </div>
+            </div>
+            <div class="form-line">
+              <div class="form-line-left">
+                <%= f.label :head_sub3, "アタマのサブパワー3" %>
+              </div>
+              <div class="form-line-right">
+                <div class="radio-gear-power" id="radio-head-sub3">
+                  <%= f.radio_button :head_sub3, "1" %>
+                  <label for="post_head_sub3_1"></label>
+                  <%= f.radio_button :head_sub3, "2" %>
+                  <label for="post_head_sub3_2"></label>
+                  <%= f.radio_button :head_sub3, "3" %>
+                  <label for="post_head_sub3_3"></label>
+                  <%= f.radio_button :head_sub3, "4" %>
+                  <label for="post_head_sub3_4"></label>
+                  <%= f.radio_button :head_sub3, "5" %>
+                  <label for="post_head_sub3_5"></label>
+                  <%= f.radio_button :head_sub3, "6" %>
+                  <label for="post_head_sub3_6"></label>
+                  <%= f.radio_button :head_sub3, "7" %>
+                  <label for="post_head_sub3_7"></label>
+                  <%= f.radio_button :head_sub3, "8" %>
+                  <label for="post_head_sub3_8"></label>
+                  <%= f.radio_button :head_sub3, "9" %>
+                  <label for="post_head_sub3_9"></label>
+                  <%= f.radio_button :head_sub3, "10" %>
+                  <label for="post_head_sub3_10"></label>
+                  <%= f.radio_button :head_sub3, "11" %>
+                  <label for="post_head_sub3_11"></label>
+                  <%= f.radio_button :head_sub3, "12" %>
+                  <label for="post_head_sub3_12"></label>
+                  <%= f.radio_button :head_sub3, "13" %>
+                  <label for="post_head_sub3_13"></label>
+                  <%= f.radio_button :head_sub3, "14" %>
+                  <label for="post_head_sub3_14"></label>
+                  <%= f.radio_button :head_sub3, "27" %>
+                  <label for="post_head_sub3_27"></label>
+                </div>
+              </div>
+            </div>
+            <div class="form-line">
+              <div class="form-line-left">
+                <%= f.label :body_main, "フクのメインパワー" %>
+              </div>
+              <div class="form-line-right">
+                <div class="radio-gear-power" id="radio-body-main">
+                  <%= f.radio_button :body_main, "1" %>
+                  <label for="post_body_main_1"></label>
+                  <%= f.radio_button :body_main, "2" %>
+                  <label for="post_body_main_2"></label>
+                  <%= f.radio_button :body_main, "3" %>
+                  <label for="post_body_main_3"></label>
+                  <%= f.radio_button :body_main, "4" %>
+                  <label for="post_body_main_4"></label>
+                  <%= f.radio_button :body_main, "5" %>
+                  <label for="post_body_main_5"></label>
+                  <%= f.radio_button :body_main, "6" %>
+                  <label for="post_body_main_6"></label>
+                  <%= f.radio_button :body_main, "7" %>
+                  <label for="post_body_main_7"></label>
+                  <%= f.radio_button :body_main, "8" %>
+                  <label for="post_body_main_8"></label>
+                  <%= f.radio_button :body_main, "9" %>
+                  <label for="post_body_main_9"></label>
+                  <%= f.radio_button :body_main, "10" %>
+                  <label for="post_body_main_10"></label>
+                  <%= f.radio_button :body_main, "11" %>
+                  <label for="post_body_main_11"></label>
+                  <%= f.radio_button :body_main, "12" %>
+                  <label for="post_body_main_12"></label>
+                  <%= f.radio_button :body_main, "13" %>
+                  <label for="post_body_main_13"></label>
+                  <%= f.radio_button :body_main, "14" %>
+                  <label for="post_body_main_14"></label>
+                  <%= f.radio_button :body_main, "19" %>
+                  <label for="post_body_main_19"></label>
+                  <%= f.radio_button :body_main, "20" %>
+                  <label for="post_body_main_20"></label>
+                  <%= f.radio_button :body_main, "21" %>
+                  <label for="post_body_main_21"></label>
+                  <%= f.radio_button :body_main, "22" %>
+                  <label for="post_body_main_22"></label>
+                  <%= f.radio_button :body_main, "23" %>
+                  <label for="post_body_main_23"></label>
+                </div>
+              </div>
+            </div>
+            <div class="form-line">
+              <div class="form-line-left">
+                <%= f.label :body_sub1, "フクのサブパワー1" %>
+              </div>
+              <div class="form-line-right">
+                <div class="radio-gear-power" id="radio-body-sub1">
+                  <%= f.radio_button :body_sub1, "1" %>
+                  <label for="post_body_sub1_1"></label>
+                  <%= f.radio_button :body_sub1, "2" %>
+                  <label for="post_body_sub1_2"></label>
+                  <%= f.radio_button :body_sub1, "3" %>
+                  <label for="post_body_sub1_3"></label>
+                  <%= f.radio_button :body_sub1, "4" %>
+                  <label for="post_body_sub1_4"></label>
+                  <%= f.radio_button :body_sub1, "5" %>
+                  <label for="post_body_sub1_5"></label>
+                  <%= f.radio_button :body_sub1, "6" %>
+                  <label for="post_body_sub1_6"></label>
+                  <%= f.radio_button :body_sub1, "7" %>
+                  <label for="post_body_sub1_7"></label>
+                  <%= f.radio_button :body_sub1, "8" %>
+                  <label for="post_body_sub1_8"></label>
+                  <%= f.radio_button :body_sub1, "9" %>
+                  <label for="post_body_sub1_9"></label>
+                  <%= f.radio_button :body_sub1, "10" %>
+                  <label for="post_body_sub1_10"></label>
+                  <%= f.radio_button :body_sub1, "11" %>
+                  <label for="post_body_sub1_11"></label>
+                  <%= f.radio_button :body_sub1, "12" %>
+                  <label for="post_body_sub1_12"></label>
+                  <%= f.radio_button :body_sub1, "13" %>
+                  <label for="post_body_sub1_13"></label>
+                  <%= f.radio_button :body_sub1, "14" %>
+                  <label for="post_body_sub1_14"></label>
+                  <%= f.radio_button :body_sub1, "27" %>
+                  <label for="post_body_sub1_27"></label>
+                </div>
+              </div>
+            </div>
+            <div class="form-line">
+              <div class="form-line-left">
+                <%= f.label :body_sub2, "フクのサブパワー2" %>
+              </div>
+              <div class="form-line-right">
+                <div class="radio-gear-power" id="radio-body-sub2">
+                  <%= f.radio_button :body_sub2, "1" %>
+                  <label for="post_body_sub2_1"></label>
+                  <%= f.radio_button :body_sub2, "2" %>
+                  <label for="post_body_sub2_2"></label>
+                  <%= f.radio_button :body_sub2, "3" %>
+                  <label for="post_body_sub2_3"></label>
+                  <%= f.radio_button :body_sub2, "4" %>
+                  <label for="post_body_sub2_4"></label>
+                  <%= f.radio_button :body_sub2, "5" %>
+                  <label for="post_body_sub2_5"></label>
+                  <%= f.radio_button :body_sub2, "6" %>
+                  <label for="post_body_sub2_6"></label>
+                  <%= f.radio_button :body_sub2, "7" %>
+                  <label for="post_body_sub2_7"></label>
+                  <%= f.radio_button :body_sub2, "8" %>
+                  <label for="post_body_sub2_8"></label>
+                  <%= f.radio_button :body_sub2, "9" %>
+                  <label for="post_body_sub2_9"></label>
+                  <%= f.radio_button :body_sub2, "10" %>
+                  <label for="post_body_sub2_10"></label>
+                  <%= f.radio_button :body_sub2, "11" %>
+                  <label for="post_body_sub2_11"></label>
+                  <%= f.radio_button :body_sub2, "12" %>
+                  <label for="post_body_sub2_12"></label>
+                  <%= f.radio_button :body_sub2, "13" %>
+                  <label for="post_body_sub2_13"></label>
+                  <%= f.radio_button :body_sub2, "14" %>
+                  <label for="post_body_sub2_14"></label>
+                  <%= f.radio_button :body_sub2, "27" %>
+                  <label for="post_body_sub2_27"></label>
+                </div>
+              </div>
+            </div>
+            <div class="form-line">
+              <div class="form-line-left">
+                <%= f.label :body_sub3, "フクのサブパワー3" %>
+              </div>
+              <div class="form-line-right">
+                <div class="radio-gear-power" id="radio-body-sub3">
+                  <%= f.radio_button :body_sub3, "1" %>
+                  <label for="post_body_sub3_1"></label>
+                  <%= f.radio_button :body_sub3, "2" %>
+                  <label for="post_body_sub3_2"></label>
+                  <%= f.radio_button :body_sub3, "3" %>
+                  <label for="post_body_sub3_3"></label>
+                  <%= f.radio_button :body_sub3, "4" %>
+                  <label for="post_body_sub3_4"></label>
+                  <%= f.radio_button :body_sub3, "5" %>
+                  <label for="post_body_sub3_5"></label>
+                  <%= f.radio_button :body_sub3, "6" %>
+                  <label for="post_body_sub3_6"></label>
+                  <%= f.radio_button :body_sub3, "7" %>
+                  <label for="post_body_sub3_7"></label>
+                  <%= f.radio_button :body_sub3, "8" %>
+                  <label for="post_body_sub3_8"></label>
+                  <%= f.radio_button :body_sub3, "9" %>
+                  <label for="post_body_sub3_9"></label>
+                  <%= f.radio_button :body_sub3, "10" %>
+                  <label for="post_body_sub3_10"></label>
+                  <%= f.radio_button :body_sub3, "11" %>
+                  <label for="post_body_sub3_11"></label>
+                  <%= f.radio_button :body_sub3, "12" %>
+                  <label for="post_body_sub3_12"></label>
+                  <%= f.radio_button :body_sub3, "13" %>
+                  <label for="post_body_sub3_13"></label>
+                  <%= f.radio_button :body_sub3, "14" %>
+                  <label for="post_body_sub3_14"></label>
+                  <%= f.radio_button :body_sub3, "27" %>
+                  <label for="post_body_sub3_27"></label>
+                </div>
+              </div>
+            </div>
+            <div class="form-line">
+              <div class="form-line-left">
+                <%= f.label :shoes_main, "クツのメインパワー" %>
+              </div>
+              <div class="form-line-right">
+                <div class="radio-gear-power" id="radio-shoes-main">
+                  <%= f.radio_button :shoes_main, "1" %>
+                  <label for="post_shoes_main_1"></label>
+                  <%= f.radio_button :shoes_main, "2" %>
+                  <label for="post_shoes_main_2"></label>
+                  <%= f.radio_button :shoes_main, "3" %>
+                  <label for="post_shoes_main_3"></label>
+                  <%= f.radio_button :shoes_main, "4" %>
+                  <label for="post_shoes_main_4"></label>
+                  <%= f.radio_button :shoes_main, "5" %>
+                  <label for="post_shoes_main_5"></label>
+                  <%= f.radio_button :shoes_main, "6" %>
+                  <label for="post_shoes_main_6"></label>
+                  <%= f.radio_button :shoes_main, "7" %>
+                  <label for="post_shoes_main_7"></label>
+                  <%= f.radio_button :shoes_main, "8" %>
+                  <label for="post_shoes_main_8"></label>
+                  <%= f.radio_button :shoes_main, "9" %>
+                  <label for="post_shoes_main_9"></label>
+                  <%= f.radio_button :shoes_main, "10" %>
+                  <label for="post_shoes_main_10"></label>
+                  <%= f.radio_button :shoes_main, "11" %>
+                  <label for="post_shoes_main_11"></label>
+                  <%= f.radio_button :shoes_main, "12" %>
+                  <label for="post_shoes_main_12"></label>
+                  <%= f.radio_button :shoes_main, "13" %>
+                  <label for="post_shoes_main_13"></label>
+                  <%= f.radio_button :shoes_main, "14" %>
+                  <label for="post_shoes_main_14"></label>
+                  <%= f.radio_button :shoes_main, "24" %>
+                  <label for="post_shoes_main_24"></label>
+                  <%= f.radio_button :shoes_main, "25" %>
+                  <label for="post_shoes_main_25"></label>
+                  <%= f.radio_button :shoes_main, "26" %>
+                  <label for="post_shoes_main_26"></label>
+                </div>
+              </div>
+            </div>
+            <div class="form-line">
+              <div class="form-line-left">
+                <%= f.label :shoes_sub1, "クツのサブパワー1" %>
+              </div>
+              <div class="form-line-right">
+                <div class="radio-gear-power" id="radio-shoes-sub1">
+                  <%= f.radio_button :shoes_sub1, "1" %>
+                  <label for="post_shoes_sub1_1"></label>
+                  <%= f.radio_button :shoes_sub1, "2" %>
+                  <label for="post_shoes_sub1_2"></label>
+                  <%= f.radio_button :shoes_sub1, "3" %>
+                  <label for="post_shoes_sub1_3"></label>
+                  <%= f.radio_button :shoes_sub1, "4" %>
+                  <label for="post_shoes_sub1_4"></label>
+                  <%= f.radio_button :shoes_sub1, "5" %>
+                  <label for="post_shoes_sub1_5"></label>
+                  <%= f.radio_button :shoes_sub1, "6" %>
+                  <label for="post_shoes_sub1_6"></label>
+                  <%= f.radio_button :shoes_sub1, "7" %>
+                  <label for="post_shoes_sub1_7"></label>
+                  <%= f.radio_button :shoes_sub1, "8" %>
+                  <label for="post_shoes_sub1_8"></label>
+                  <%= f.radio_button :shoes_sub1, "9" %>
+                  <label for="post_shoes_sub1_9"></label>
+                  <%= f.radio_button :shoes_sub1, "10" %>
+                  <label for="post_shoes_sub1_10"></label>
+                  <%= f.radio_button :shoes_sub1, "11" %>
+                  <label for="post_shoes_sub1_11"></label>
+                  <%= f.radio_button :shoes_sub1, "12" %>
+                  <label for="post_shoes_sub1_12"></label>
+                  <%= f.radio_button :shoes_sub1, "13" %>
+                  <label for="post_shoes_sub1_13"></label>
+                  <%= f.radio_button :shoes_sub1, "14" %>
+                  <label for="post_shoes_sub1_14"></label>
+                  <%= f.radio_button :shoes_sub1, "27" %>
+                  <label for="post_shoes_sub1_27"></label>
+                </div>
+              </div>
+            </div>
+            <div class="form-line">
+              <div class="form-line-left">
+                <%= f.label :shoes_sub2, "クツのサブパワー2" %>
+              </div>
+              <div class="form-line-right">
+                <div class="radio-gear-power" id="radio-shoes-sub2">
+                  <%= f.radio_button :shoes_sub2, "1" %>
+                  <label for="post_shoes_sub2_1"></label>
+                  <%= f.radio_button :shoes_sub2, "2" %>
+                  <label for="post_shoes_sub2_2"></label>
+                  <%= f.radio_button :shoes_sub2, "3" %>
+                  <label for="post_shoes_sub2_3"></label>
+                  <%= f.radio_button :shoes_sub2, "4" %>
+                  <label for="post_shoes_sub2_4"></label>
+                  <%= f.radio_button :shoes_sub2, "5" %>
+                  <label for="post_shoes_sub2_5"></label>
+                  <%= f.radio_button :shoes_sub2, "6" %>
+                  <label for="post_shoes_sub2_6"></label>
+                  <%= f.radio_button :shoes_sub2, "7" %>
+                  <label for="post_shoes_sub2_7"></label>
+                  <%= f.radio_button :shoes_sub2, "8" %>
+                  <label for="post_shoes_sub2_8"></label>
+                  <%= f.radio_button :shoes_sub2, "9" %>
+                  <label for="post_shoes_sub2_9"></label>
+                  <%= f.radio_button :shoes_sub2, "10" %>
+                  <label for="post_shoes_sub2_10"></label>
+                  <%= f.radio_button :shoes_sub2, "11" %>
+                  <label for="post_shoes_sub2_11"></label>
+                  <%= f.radio_button :shoes_sub2, "12" %>
+                  <label for="post_shoes_sub2_12"></label>
+                  <%= f.radio_button :shoes_sub2, "13" %>
+                  <label for="post_shoes_sub2_13"></label>
+                  <%= f.radio_button :shoes_sub2, "14" %>
+                  <label for="post_shoes_sub2_14"></label>
+                  <%= f.radio_button :shoes_sub2, "27" %>
+                  <label for="post_shoes_sub2_27"></label>
+                </div>
+              </div>
+            </div>
+            <div class="form-line">
+              <div class="form-line-left">
+                <%= f.label :shoes_sub3, "クツのサブパワー3" %>
+              </div>
+              <div class="form-line-right">
+                <div class="radio-gear-power" id="radio-shoes-sub3">
+                  <%= f.radio_button :shoes_sub3, "1" %>
+                  <label for="post_shoes_sub3_1"></label>
+                  <%= f.radio_button :shoes_sub3, "2" %>
+                  <label for="post_shoes_sub3_2"></label>
+                  <%= f.radio_button :shoes_sub3, "3" %>
+                  <label for="post_shoes_sub3_3"></label>
+                  <%= f.radio_button :shoes_sub3, "4" %>
+                  <label for="post_shoes_sub3_4"></label>
+                  <%= f.radio_button :shoes_sub3, "5" %>
+                  <label for="post_shoes_sub3_5"></label>
+                  <%= f.radio_button :shoes_sub3, "6" %>
+                  <label for="post_shoes_sub3_6"></label>
+                  <%= f.radio_button :shoes_sub3, "7" %>
+                  <label for="post_shoes_sub3_7"></label>
+                  <%= f.radio_button :shoes_sub3, "8" %>
+                  <label for="post_shoes_sub3_8"></label>
+                  <%= f.radio_button :shoes_sub3, "9" %>
+                  <label for="post_shoes_sub3_9"></label>
+                  <%= f.radio_button :shoes_sub3, "10" %>
+                  <label for="post_shoes_sub3_10"></label>
+                  <%= f.radio_button :shoes_sub3, "11" %>
+                  <label for="post_shoes_sub3_11"></label>
+                  <%= f.radio_button :shoes_sub3, "12" %>
+                  <label for="post_shoes_sub3_12"></label>
+                  <%= f.radio_button :shoes_sub3, "13" %>
+                  <label for="post_shoes_sub3_13"></label>
+                  <%= f.radio_button :shoes_sub3, "14" %>
+                  <label for="post_shoes_sub3_14"></label>
+                  <%= f.radio_button :shoes_sub3, "27" %>
+                  <label for="post_shoes_sub3_27"></label>
+                </div>
+              </div>
+            </div>
+            <div class="form-line-submit">
+              <%= f.submit "更新する", class: "hover-transform" %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<%= link_to "＋投稿する", new_post_path, class: "fixed_to_post_link" %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -58,10 +58,7 @@
                 <span class="length-supplement">(250文字まで)</span>
               </div>
               <div class="form-line-right">
-                <div class="FlexTextarea">
-                  <div class="FlexTextarea__dummy" aria-hidden="true"></div>
-                  <%= f.text_area :comment, class: "FlexTextarea__textarea", maxlength: 250, placeholder: "編成のポイントやおすすめの立ち回りを入力してください" %>
-                </div>
+                <%= f.text_area :comment, maxlength: 250, placeholder: "編成のポイントやおすすめの立ち回りを入力してください" %>
               </div>
             </div>
             <div class="form-line">
@@ -571,5 +568,4 @@
     </div>
   </div>
 </div>
-<%= javascript_pack_tag 'users/adjust_textarea' %>
 <%= javascript_pack_tag 'posts/required_radio_message_off' %>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -40,10 +40,7 @@
             <span class="length-supplement">(100文字まで)</span>
           </div>
           <div class="form-line-right">
-            <div class="FlexTextarea">
-              <div class="FlexTextarea__dummy" aria-hidden="true"></div>
-              <%= f.text_area :profile, class: "FlexTextarea__textarea", maxlength: 100 %>
-            </div>
+            <%= f.text_area :profile, maxlength: 100 %>
           </div>
         </div>
         <div class="form-line">
@@ -114,5 +111,4 @@
     </div>
   </div>
 </div>
-<%= javascript_pack_tag 'users/adjust_textarea' %>
 <%= javascript_pack_tag 'users/show_password' %>

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -56,3 +56,8 @@ crumb :posts_show do |post|
   link post.title, post_path(post)
   parent :posts_index
 end
+
+crumb :posts_edit do |post|
+  link "投稿編集", edit_post_path(post)
+  parent :posts_show, post
+end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -4,6 +4,10 @@ ja:
       post: 投稿
     attributes:
       post:
+        title: タイトル
+        weapon: おすすめブキ
+        battle: おすすめバトル
+        comment: コメント
         head_main: アタマのメインパワー
         head_sub1: アタマのサブパワー1
         head_sub2: アタマのサブパワー2

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -2,18 +2,18 @@ FactoryBot.define do
   factory :post do
     title { Faker::Lorem.characters(number: 10) }
     comment { Faker::Lorem.characters(number: 50) }
-    head_main { Faker::Number.between(from: 1, to: 27) }
-    head_sub1 { Faker::Number.between(from: 1, to: 27) }
-    head_sub2 { Faker::Number.between(from: 1, to: 27) }
-    head_sub3 { Faker::Number.between(from: 1, to: 27) }
-    body_main { Faker::Number.between(from: 1, to: 27) }
-    body_sub1 { Faker::Number.between(from: 1, to: 27) }
-    body_sub2 { Faker::Number.between(from: 1, to: 27) }
-    body_sub3 { Faker::Number.between(from: 1, to: 27) }
-    shoes_main { Faker::Number.between(from: 1, to: 27) }
-    shoes_sub1 { Faker::Number.between(from: 1, to: 27) }
-    shoes_sub2 { Faker::Number.between(from: 1, to: 27) }
-    shoes_sub3 { Faker::Number.between(from: 1, to: 27) }
+    head_main { Faker::Number.between(from: 1, to: 14) }
+    head_sub1 { Faker::Number.between(from: 1, to: 14) }
+    head_sub2 { Faker::Number.between(from: 1, to: 14) }
+    head_sub3 { Faker::Number.between(from: 1, to: 14) }
+    body_main { Faker::Number.between(from: 1, to: 14) }
+    body_sub1 { Faker::Number.between(from: 1, to: 14) }
+    body_sub2 { Faker::Number.between(from: 1, to: 14) }
+    body_sub3 { Faker::Number.between(from: 1, to: 14) }
+    shoes_main { Faker::Number.between(from: 1, to: 14) }
+    shoes_sub1 { Faker::Number.between(from: 1, to: 14) }
+    shoes_sub2 { Faker::Number.between(from: 1, to: 14) }
+    shoes_sub3 { Faker::Number.between(from: 1, to: 14) }
     user
   end
 end

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -160,4 +160,24 @@ RSpec.describe "Posts", type: :request do
       expect(response.body).to include post.comment
     end
   end
+
+  describe "GET /edit" do
+    let(:post) { create(:post, weapon: "わかばシューター", battle: "ガチヤグラ") }
+
+    before do
+      sign_in post.user
+      get edit_post_path(post)
+    end
+
+    it "正常なレスポンスを返すこと" do
+      expect(response).to have_http_status(:success)
+    end
+
+    it "投稿の各情報を取得していること" do
+      expect(response.body).to include post.title
+      expect(response.body).to include post.weapon
+      expect(response.body).to include post.battle
+      expect(response.body).to include post.comment
+    end
+  end
 end


### PR DESCRIPTION
### 概要
投稿機能（posts）として、投稿編集ページ（edit）の作成を行う。

### やったこと
・投稿編集ページを作成
・投稿編集ページのrequest specを作成
・投稿編集ページのsystem specを作成

### 備考
ユーザー登録ページとユーザー編集ページに採用していた`adjust_textarea.js`を本リポジトリで削除しています。
投稿編集ページにも採用しようとしたところ、高さの自動調整の挙動を制御しきれていないことに気づいたため、削除しました。