### PR TITLE
お気に入り機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,3 +78,5 @@ gem 'devise'
 gem 'dotenv-rails'
 
 gem 'ransack'
+
+gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,6 +129,10 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     jmespath (1.6.1)
+    jquery-rails (4.5.1)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
     launchy (2.5.0)
       addressable (~> 2.7)
     listen (3.7.1)
@@ -344,6 +348,7 @@ DEPENDENCIES
   faker
   gretel
   jbuilder (~> 2.7)
+  jquery-rails
   launchy
   listen (~> 3.3)
   net-imap

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -71,14 +71,6 @@ textarea {
 .hover-transform:hover {
   transform: scale(1.03);
 }
-.hover-color-red:hover {
-  color: rgb(245, 69, 98);
-}
-.hover-i-color-red:hover {
-  i {
-    color: rgb(245, 69, 98);
-  }
-}
 .font-weight-bold {
   font-weight: bold;
 }

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -149,13 +149,8 @@
   justify-content: space-between;
   align-items: center;
   font-size: 0.9rem;
-}
-.post-bookmark {
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-  p {
-    margin-left: 3px;
+  i {
+    margin-right: 4px;
   }
 }
 .posts-search {
@@ -255,107 +250,136 @@
     width: 68%;
   }
 }
-input[type="radio"] {
-  display: none;
-}
-input[type="radio"]+label::before {
-  content: "";
-  display: inline-block;
-  background-size: contain;
-  width: 40px;
-  height: 40px;
-  opacity: 0.7;
-}
-input[type="radio"]:hover+label::before {
-  opacity: 1;
-}
-input[type="radio"]:checked+label::before {
-  border: 4px solid rgb(89, 89, 255);
-  border-radius: 50%;
-  box-sizing: border-box;
-  box-shadow: 0 0 10px 0 rgba(89, 89, 255, 0.9);
-  opacity: 1;
+.radio-gear-power {
+  input[type="radio"] {
+    display: none;
+  }
+  input[type="radio"]+label::before {
+    content: "";
+    display: inline-block;
+    background-size: contain;
+    width: 40px;
+    height: 40px;
+    opacity: 0.7;
+  }
+  input[type="radio"]:hover+label::before {
+    opacity: 1;
+  }
+  input[type="radio"]:checked+label::before {
+    border: 4px solid rgb(89, 89, 255);
+    border-radius: 50%;
+    box-sizing: border-box;
+    box-shadow: 0 0 10px 0 rgba(89, 89, 255, 0.9);
+    opacity: 1;
+  }
 }
 input[type="radio"][value="1"]+label::before {
   background-image: url("/gear_powers/gear_power_1.png");
+  cursor: pointer;
 }
 input[type="radio"][value="2"]+label::before {
   background-image: url("/gear_powers/gear_power_2.png");
+  cursor: pointer;
 }
 input[type="radio"][value="3"]+label::before {
   background-image: url("/gear_powers/gear_power_3.png");
+  cursor: pointer;
 }
 input[type="radio"][value="4"]+label::before {
   background-image: url("/gear_powers/gear_power_4.png");
+  cursor: pointer;
 }
 input[type="radio"][value="5"]+label::before {
   background-image: url("/gear_powers/gear_power_5.png");
+  cursor: pointer;
 }
 input[type="radio"][value="6"]+label::before {
   background-image: url("/gear_powers/gear_power_6.png");
+  cursor: pointer;
 }
 input[type="radio"][value="7"]+label::before {
   background-image: url("/gear_powers/gear_power_7.png");
+  cursor: pointer;
 }
 input[type="radio"][value="8"]+label::before {
   background-image: url("/gear_powers/gear_power_8.png");
+  cursor: pointer;
 }
 input[type="radio"][value="9"]+label::before {
   background-image: url("/gear_powers/gear_power_9.png");
+  cursor: pointer;
 }
 input[type="radio"][value="10"]+label::before {
   background-image: url("/gear_powers/gear_power_10.png");
+  cursor: pointer;
 }
 input[type="radio"][value="11"]+label::before {
   background-image: url("/gear_powers/gear_power_11.png");
+  cursor: pointer;
 }
 input[type="radio"][value="12"]+label::before {
   background-image: url("/gear_powers/gear_power_12.png");
+  cursor: pointer;
 }
 input[type="radio"][value="13"]+label::before {
   background-image: url("/gear_powers/gear_power_13.png");
+  cursor: pointer;
 }
 input[type="radio"][value="14"]+label::before {
   background-image: url("/gear_powers/gear_power_14.png");
+  cursor: pointer;
 }
 input[type="radio"][value="15"]+label::before {
   background-image: url("/gear_powers/gear_power_15.png");
+  cursor: pointer;
 }
 input[type="radio"][value="16"]+label::before {
   background-image: url("/gear_powers/gear_power_16.png");
+  cursor: pointer;
 }
 input[type="radio"][value="17"]+label::before {
   background-image: url("/gear_powers/gear_power_17.png");
+  cursor: pointer;
 }
 input[type="radio"][value="18"]+label::before {
   background-image: url("/gear_powers/gear_power_18.png");
+  cursor: pointer;
 }
 input[type="radio"][value="19"]+label::before {
   background-image: url("/gear_powers/gear_power_19.png");
+  cursor: pointer;
 }
 input[type="radio"][value="20"]+label::before {
   background-image: url("/gear_powers/gear_power_20.png");
+  cursor: pointer;
 }
 input[type="radio"][value="21"]+label::before {
   background-image: url("/gear_powers/gear_power_21.png");
+  cursor: pointer;
 }
 input[type="radio"][value="22"]+label::before {
   background-image: url("/gear_powers/gear_power_22.png");
+  cursor: pointer;
 }
 input[type="radio"][value="23"]+label::before {
   background-image: url("/gear_powers/gear_power_23.png");
+  cursor: pointer;
 }
 input[type="radio"][value="24"]+label::before {
   background-image: url("/gear_powers/gear_power_24.png");
+  cursor: pointer;
 }
 input[type="radio"][value="25"]+label::before {
   background-image: url("/gear_powers/gear_power_25.png");
+  cursor: pointer;
 }
 input[type="radio"][value="26"]+label::before {
   background-image: url("/gear_powers/gear_power_26.png");
+  cursor: pointer;
 }
 input[type="radio"][value="27"]+label::before {
   background-image: url("/gear_powers/gear_power_27.png");
+  cursor: pointer;
 }
 
 /*=== POSTS/SHOW ===*/
@@ -367,7 +391,6 @@ input[type="radio"][value="27"]+label::before {
   width: fit-content;
   margin-top: 15px;
   a {
-    transition: all .3s;
     display: block;
   }
 }
@@ -379,6 +402,7 @@ input[type="radio"][value="27"]+label::before {
   margin-right: 10px;
   color: #fff;
   font-size: 0.9rem;
+  transition: all .3s;
 }
 .bookmark-button {
   display: flex;
@@ -444,6 +468,58 @@ input[type="radio"][value="27"]+label::before {
 }
 @media screen and (max-width: 520px) {
   .post-show-comment {
+    font-size: 0.85rem;
+  }
+}
+.post-show-favorited {
+  margin-bottom: 10px;
+  h3 {
+    font-size: 1.3rem;
+    line-height: 1.6rem;
+    margin-right: 10px;
+    padding-left: 7px;
+    border-left: 2px solid #333;
+  }
+  a {
+    transition: all .3s;
+  }
+  i {
+    margin-right: 4px;
+  }
+}
+@media screen and (max-width: 520px) {
+  .post-show-favorited {
+    h3 {
+      font-size: 1.15rem;
+      line-height: 1.5rem;
+      margin-bottom: 10px;
+    }
+    a {
+      width: fit-content;
+    }
+  }
+}
+@media screen and (min-width: 521px) {
+  .post-show-favorited {
+    display: flex;
+    align-items: center;
+  }
+}
+.post-show-favorited-container {
+  font-size: 0.9rem;
+  margin-bottom: 30px;
+  li {
+    margin-bottom: 5px;
+  }
+  img {
+    width: 40px;
+    height: 40px;
+    object-fit: cover;
+    margin-right: 5px;
+  }
+}
+@media screen and (max-width: 520px) {
+  .post-show-favorited-container {
     font-size: 0.85rem;
   }
 }

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -269,6 +269,46 @@
 .vertical-border {
   border-left: 1px solid #fff;
 }
+.toggle-radio {
+  display: flex;
+  justify-content: space-between;
+  max-width: 200px;
+  margin: 0 auto;
+  padding-bottom: 10px;
+  input[type="radio"] {
+    display: none;
+  }
+  label {
+    padding-bottom: 3px;
+    font-size: 1.1rem;
+    font-weight: bold;
+    opacity: 0.7;
+    cursor: pointer;
+  }
+  label:hover {
+    opacity: 1;
+  }
+  input[type="radio"]:checked+label {
+    border-bottom: 4px solid #333;
+    opacity: 1;
+  }
+}
+@media screen and (max-width: 520px) {
+  .toggle-radio {
+    label {
+      font-size: 0.9rem;
+    }
+  }
+}
+.toggle {
+  display: none;
+}
+.toggle-posts {
+  display: block;
+}
+.toggle-hide-space {
+  width: 100px;
+}
 .no-post-message {
   display: flex;
   align-items: center;

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,0 +1,14 @@
+class FavoritesController < ApplicationController
+  before_action :authenticate_user!
+
+  def create
+    Favorite.create(user_id: current_user.id, post_id: params[:post_id])
+    redirect_back fallback_location: root_path
+  end
+
+  def destroy
+    @favorite = Favorite.find_by(user_id: current_user.id, post_id: params[:post_id])
+    @favorite.destroy
+    redirect_back fallback_location: root_path
+  end
+end

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -2,13 +2,13 @@ class FavoritesController < ApplicationController
   before_action :authenticate_user!
 
   def create
+    @post = Post.find(params[:post_id])
     Favorite.create(user_id: current_user.id, post_id: params[:post_id])
-    redirect_back fallback_location: root_path
   end
 
   def destroy
-    @favorite = Favorite.find_by(user_id: current_user.id, post_id: params[:post_id])
-    @favorite.destroy
-    redirect_back fallback_location: root_path
+    @post = Post.find(params[:post_id])
+    favorite = Favorite.find_by(user_id: current_user.id, post_id: params[:post_id])
+    favorite.destroy
   end
 end

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,5 +1,5 @@
 class FavoritesController < ApplicationController
-  before_action :authenticate_user!
+  before_action :authenticate_user
 
   def create
     @post = Post.find(params[:post_id])
@@ -10,5 +10,13 @@ class FavoritesController < ApplicationController
     @post = Post.find(params[:post_id])
     favorite = Favorite.find_by(user_id: current_user.id, post_id: params[:post_id])
     favorite.destroy
+  end
+
+  # ajax通信ではdeviseのauthenticate_user!が使えないため独自に定義
+  def authenticate_user
+    if current_user.nil?
+      flash[:alert] = "アカウント登録もしくはログインしてください。"
+      redirect_to new_user_session_path
+    end
   end
 end

--- a/app/javascript/packs/users/toggle.js
+++ b/app/javascript/packs/users/toggle.js
@@ -1,0 +1,11 @@
+$(function() {
+  $('[name="toggle"]:radio').change( function() {
+    if($('[id=toggle_posts]').prop('checked')){
+      $('.toggle').hide();
+      $('.toggle-posts').show();
+    } else if ($('[id=toggle_favorites]').prop('checked')) {
+      $('.toggle').hide();
+      $('.toggle-favorites').show();
+    } 
+  });
+});

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -1,0 +1,6 @@
+class Favorite < ApplicationRecord
+  validates_uniqueness_of :post_id, scope: :user_id
+
+  belongs_to :user
+  belongs_to :post
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -17,6 +17,7 @@ class Post < ApplicationRecord
   validates :shoes_sub3, { presence: true }
 
   belongs_to :user
+  has_many :favorites, dependent: :destroy
 
   SELECT_WEAPON_OPTIONS = [
     [

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,7 @@ class User < ApplicationRecord
 
   has_one_attached :image
   has_many :posts, dependent: :destroy
+  has_many :favorites, dependent: :destroy
 
   def update_without_current_password(params, *options)
     params.delete(:current_password)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,4 +35,8 @@ class User < ApplicationRecord
       user.name = "ゲスト"
     end
   end
+
+  def already_favorited?(post)
+    favorites.exists?(post_id: post.id)
+  end
 end

--- a/app/views/favorites/_favorite.html.erb
+++ b/app/views/favorites/_favorite.html.erb
@@ -1,0 +1,18 @@
+<% if user_signed_in? %>
+  <% if current_user.already_favorited?(post) %>
+    <%= link_to post_favorite_path(post, post), method: :delete, remote: true, class: "bookmark-button hover-opacity" do %>
+      <i class="fas fa-bookmark font-awesome-size-105"></i>
+      <%= post.favorites.count %>件
+    <% end %>
+  <% else %>
+    <%= link_to post_favorites_path(post), method: :post, remote: true, class: "bookmark-button hover-opacity" do %>
+      <i class="far fa-bookmark font-awesome-size-105"></i>
+      <%= post.favorites.count %>件
+    <% end %>
+  <% end %>
+<% else %>
+  <%= link_to post_favorites_path(post), method: :post, remote: true, class: "bookmark-button hover-opacity" do %>
+    <i class="far fa-bookmark font-awesome-size-105"></i>
+    <%= post.favorites.count %>件
+  <% end %>
+<% end %>

--- a/app/views/favorites/create.js.erb
+++ b/app/views/favorites/create.js.erb
@@ -1,0 +1,2 @@
+$('.favorite_button_<%= @post.id %>').html("<%= j(render 'favorites/favorite', post: @post) %>");
+$('.post-show-favorited-container').html("<%= j(render 'posts/users_who_favorited', post: @post) %>");

--- a/app/views/favorites/destroy.js.erb
+++ b/app/views/favorites/destroy.js.erb
@@ -1,0 +1,2 @@
+$('.favorite_button_<%= @post.id %>').html("<%= j(render 'favorites/favorite', post: @post) %>");
+$('.post-show-favorited-container').html("<%= j(render 'posts/users_who_favorited', post: @post) %>");

--- a/app/views/posts/_favorited_post.html.erb
+++ b/app/views/posts/_favorited_post.html.erb
@@ -1,0 +1,104 @@
+<div class="post">
+  <div class="post-container">
+    <div class="post-header">
+      <div class="post-header-user">
+        <div class="post-user-icon">
+          <% if favorite.post.user.image.present? %>
+            <%= link_to (image_tag favorite.post.user.image, alt: "#{favorite.post.user.name}のユーザーアイコン"), user_path(favorite.post.user), class: "hover-opacity" %>
+          <% else %>
+            <%= link_to (image_tag "/user_image/user_image_default_bk.png", alt: "デフォルトユーザーアイコン"), user_path(favorite.post.user), class: "hover-opacity" %>
+          <% end %>
+        </div>
+        <div class="post-user-info">
+          <%= link_to favorite.post.user.name, user_path(favorite.post.user), class: "hover-textdecoration" %>
+          <p class="post-user-time"><%= favorite.post.created_at.to_s(:custom_no_year) %></p>
+        </div>
+      </div>
+      <div class="post-header-title">
+        <div class="post-title">
+          <%= link_to favorite.post.title, post_path(favorite.post), class: "hover-textdecoration" %>
+        </div>
+        <div class="post-recommend">
+          <p>おすすめブキ：<%= favorite.post.weapon %></p>
+          <p>おすすめバトル：<%= favorite.post.battle %></p>
+        </div>
+      </div>
+    </div>
+    <div class="post-center">
+      <div class="post-center-one">
+        <div class="post-gearcategory">
+          <i class="fa-solid fa-hat-cowboy font-awesome-color-black"></i>
+          <p>アタマ</p>
+        </div>
+        <hr class="post-hr">
+        <div class="post-gearpowers">
+          <div class="post-main-gearpower">
+            <%= link_to (image_tag "/gear_powers/gear_power_#{favorite.post.head_main}.png", alt: "ギアパワー"), gear_power_path(favorite.post.head_main), class: "hover-brightness" %>
+          </div>
+          <div class="post-sub-gearpowers">
+            <%= link_to (image_tag "/gear_powers/gear_power_#{favorite.post.head_sub1}.png", alt: "ギアパワー"), gear_power_path(favorite.post.head_sub1), class: "hover-brightness" %>
+            <%= link_to (image_tag "/gear_powers/gear_power_#{favorite.post.head_sub2}.png", alt: "ギアパワー"), gear_power_path(favorite.post.head_sub2), class: "hover-brightness" %>
+            <%= link_to (image_tag "/gear_powers/gear_power_#{favorite.post.head_sub3}.png", alt: "ギアパワー"), gear_power_path(favorite.post.head_sub3), class: "hover-brightness" %>
+          </div>
+        </div>
+      </div>
+      <div class="post-center-one">
+        <div class="post-gearcategory">
+          <i class="fa-solid fa-shirt font-awesome-color-black"></i>
+          <p>フク</p>
+        </div>
+        <hr class="post-hr">
+        <div class="post-gearpowers">
+          <div class="post-main-gearpower">
+            <%= link_to (image_tag "/gear_powers/gear_power_#{favorite.post.body_main}.png", alt: "ギアパワー"), gear_power_path(favorite.post.body_main), class: "hover-brightness" %>
+          </div>
+          <div class="post-sub-gearpowers">
+            <%= link_to (image_tag "/gear_powers/gear_power_#{favorite.post.body_sub1}.png", alt: "ギアパワー"), gear_power_path(favorite.post.body_sub1), class: "hover-brightness" %>
+            <%= link_to (image_tag "/gear_powers/gear_power_#{favorite.post.body_sub2}.png", alt: "ギアパワー"), gear_power_path(favorite.post.body_sub2), class: "hover-brightness" %>
+            <%= link_to (image_tag "/gear_powers/gear_power_#{favorite.post.body_sub3}.png", alt: "ギアパワー"), gear_power_path(favorite.post.body_sub3), class: "hover-brightness" %>
+          </div>
+        </div>
+      </div>
+      <div class="post-center-one">
+        <div class="post-gearcategory">
+          <i class="fa-solid fa-shoe-prints font-awesome-color-black"></i>
+          <p>クツ</p>
+        </div>
+        <hr class="post-hr">
+        <div class="post-gearpowers">
+          <div class="post-main-gearpower">
+            <%= link_to (image_tag "/gear_powers/gear_power_#{favorite.post.shoes_main}.png", alt: "ギアパワー"), gear_power_path(favorite.post.shoes_main), class: "hover-brightness" %>
+          </div>
+          <div class="post-sub-gearpowers">
+            <%= link_to (image_tag "/gear_powers/gear_power_#{favorite.post.shoes_sub1}.png", alt: "ギアパワー"), gear_power_path(favorite.post.shoes_sub1), class: "hover-brightness" %>
+            <%= link_to (image_tag "/gear_powers/gear_power_#{favorite.post.shoes_sub2}.png", alt: "ギアパワー"), gear_power_path(favorite.post.shoes_sub2), class: "hover-brightness" %>
+            <%= link_to (image_tag "/gear_powers/gear_power_#{favorite.post.shoes_sub3}.png", alt: "ギアパワー"), gear_power_path(favorite.post.shoes_sub3), class: "hover-brightness" %>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="post-footer">
+      <% if user_signed_in? %>
+        <% if current_user.already_favorited?(favorite.post) %>
+          <%= link_to post_favorite_path(favorite.post, favorite.post), method: :delete, class: "bookmark-button hover-opacity" do %>
+            <i class="fas fa-bookmark font-awesome-size-105"></i>
+            <%= favorite.post.favorites.count %>件
+          <% end %>
+        <% else %>
+          <%= link_to post_favorites_path(favorite.post), method: :post, class: "bookmark-button hover-opacity" do %>
+            <i class="far fa-bookmark font-awesome-size-105"></i>
+            <%= favorite.post.favorites.count %>件
+          <% end %>
+        <% end %>
+      <% else %>
+        <%= link_to post_favorites_path(favorite.post), method: :post, class: "bookmark-button hover-opacity" do %>
+          <i class="far fa-bookmark font-awesome-size-105"></i>
+          <%= favorite.post.favorites.count %>件
+        <% end %>
+      <% end %>
+      <div class="post-to-show">
+        <%= link_to "&gt; 編成詳細へ".html_safe, post_path(favorite.post), class: "hover-textdecoration" %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/posts/_favorited_post.html.erb
+++ b/app/views/posts/_favorited_post.html.erb
@@ -78,24 +78,9 @@
       </div>
     </div>
     <div class="post-footer">
-      <% if user_signed_in? %>
-        <% if current_user.already_favorited?(favorite.post) %>
-          <%= link_to post_favorite_path(favorite.post, favorite.post), method: :delete, class: "bookmark-button hover-opacity" do %>
-            <i class="fas fa-bookmark font-awesome-size-105"></i>
-            <%= favorite.post.favorites.count %>件
-          <% end %>
-        <% else %>
-          <%= link_to post_favorites_path(favorite.post), method: :post, class: "bookmark-button hover-opacity" do %>
-            <i class="far fa-bookmark font-awesome-size-105"></i>
-            <%= favorite.post.favorites.count %>件
-          <% end %>
-        <% end %>
-      <% else %>
-        <%= link_to post_favorites_path(favorite.post), method: :post, class: "bookmark-button hover-opacity" do %>
-          <i class="far fa-bookmark font-awesome-size-105"></i>
-          <%= favorite.post.favorites.count %>件
-        <% end %>
-      <% end %>
+      <div class="favorite_button_<%= favorite.post.id %>">
+        <%= render "favorites/favorite", post: favorite.post %>
+      </div>
       <div class="post-to-show">
         <%= link_to "&gt; 編成詳細へ".html_safe, post_path(favorite.post), class: "hover-textdecoration" %>
       </div>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -78,11 +78,23 @@
       </div>
     </div>
     <div class="post-footer">
-      <%= link_to "#" do %>
-        <div class="post-bookmark hover-color-red hover-i-color-red">
-          <i class="far fa-bookmark font-awesome-color-black font-awesome-size-105"></i>
-          <p>#件</p>
-        </div>
+      <% if user_signed_in? %>
+        <% if current_user.already_favorited?(post) %>
+          <%= link_to post_favorite_path(post, post), method: :delete, class: "bookmark-button hover-opacity" do %>
+            <i class="fas fa-bookmark font-awesome-size-105"></i>
+            <%= post.favorites.count %>件
+          <% end %>
+        <% else %>
+          <%= link_to post_favorites_path(post), method: :post, class: "bookmark-button hover-opacity" do %>
+            <i class="far fa-bookmark font-awesome-size-105"></i>
+            <%= post.favorites.count %>件
+          <% end %>
+        <% end %>
+      <% else %>
+        <%= link_to post_favorites_path(post), method: :post, class: "bookmark-button hover-opacity" do %>
+          <i class="far fa-bookmark font-awesome-size-105"></i>
+          <%= post.favorites.count %>件
+        <% end %>
       <% end %>
       <div class="post-to-show">
         <%= link_to "&gt; 編成詳細へ".html_safe, post_path(post), class: "hover-textdecoration" %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -78,24 +78,9 @@
       </div>
     </div>
     <div class="post-footer">
-      <% if user_signed_in? %>
-        <% if current_user.already_favorited?(post) %>
-          <%= link_to post_favorite_path(post, post), method: :delete, class: "bookmark-button hover-opacity" do %>
-            <i class="fas fa-bookmark font-awesome-size-105"></i>
-            <%= post.favorites.count %>件
-          <% end %>
-        <% else %>
-          <%= link_to post_favorites_path(post), method: :post, class: "bookmark-button hover-opacity" do %>
-            <i class="far fa-bookmark font-awesome-size-105"></i>
-            <%= post.favorites.count %>件
-          <% end %>
-        <% end %>
-      <% else %>
-        <%= link_to post_favorites_path(post), method: :post, class: "bookmark-button hover-opacity" do %>
-          <i class="far fa-bookmark font-awesome-size-105"></i>
-          <%= post.favorites.count %>件
-        <% end %>
-      <% end %>
+      <div class="favorite_button_<%= post.id %>">
+        <%= render "favorites/favorite", post: post %>
+      </div>
       <div class="post-to-show">
         <%= link_to "&gt; 編成詳細へ".html_safe, post_path(post), class: "hover-textdecoration" %>
       </div>

--- a/app/views/posts/_user_who_favorited.html.erb
+++ b/app/views/posts/_user_who_favorited.html.erb
@@ -1,0 +1,10 @@
+<li>
+  <%= link_to user_path(favorite.user), class: "in-td-row radius-50 hover-textdecoration hover-opacity" do %>
+    <% if favorite.user.image.present? %>
+      <%= image_tag favorite.user.image, alt: "#{favorite.user.name}のユーザーアイコン" %>
+    <% else %>
+      <%= image_tag "/user_image/user_image_default_bk.png", alt: "デフォルトユーザーアイコン" %>
+    <% end %>
+    <%= favorite.user.name %>
+  <% end %>
+</li>

--- a/app/views/posts/_users_who_favorited.html.erb
+++ b/app/views/posts/_users_who_favorited.html.erb
@@ -1,10 +1,7 @@
-<li>
-  <%= link_to user_path(favorite.user), class: "in-td-row radius-50 hover-textdecoration hover-opacity" do %>
-    <% if favorite.user.image.present? %>
-      <%= image_tag favorite.user.image, alt: "#{favorite.user.name}のユーザーアイコン" %>
-    <% else %>
-      <%= image_tag "/user_image/user_image_default_bk.png", alt: "デフォルトユーザーアイコン" %>
-    <% end %>
-    <%= favorite.user.name %>
-  <% end %>
-</li>
+<% if post.favorites.present? %>
+  <ul>
+    <%= render partial: "posts/user_who_favorited", collection: post.favorites.order(created_at: :desc), as: "favorite" %>
+  </ul>
+<% else %>
+  <p>まだお気に入りされていません。</p>
+<% end %>

--- a/app/views/posts/_users_who_favorited.html.erb
+++ b/app/views/posts/_users_who_favorited.html.erb
@@ -1,0 +1,10 @@
+<li>
+  <%= link_to user_path(favorite.user), class: "in-td-row radius-50 hover-textdecoration hover-opacity" do %>
+    <% if favorite.user.image.present? %>
+      <%= image_tag favorite.user.image, alt: "#{favorite.user.name}のユーザーアイコン" %>
+    <% else %>
+      <%= image_tag "/user_image/user_image_default_bk.png", alt: "デフォルトユーザーアイコン" %>
+    <% end %>
+    <%= favorite.user.name %>
+  <% end %>
+</li>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -212,6 +212,36 @@
           <p><%= @post.comment %></p>
         <% end %>
       </div>
+      <div class="post-show-favorited">
+        <h3>お気に入りしたユーザー</h3>
+        <% if user_signed_in? %>
+          <% if current_user.already_favorited?(@post) %>
+            <%= link_to post_favorite_path(@post), method: :delete, class: "bookmark-button hover-opacity" do %>
+              <i class="fas fa-bookmark font-awesome-size-105"></i>
+              <%= @post.favorites.count %>件
+            <% end %>
+          <% else %>
+            <%= link_to post_favorites_path(@post), method: :post, class: "bookmark-button hover-opacity" do %>
+              <i class="far fa-bookmark font-awesome-size-105"></i>
+              <%= @post.favorites.count %>件
+            <% end %>
+          <% end %>
+        <% else %>
+          <%= link_to post_favorites_path(@post), method: :post, class: "bookmark-button hover-opacity" do %>
+            <i class="far fa-bookmark font-awesome-size-105"></i>
+            <%= @post.favorites.count %>件
+          <% end %>
+        <% end %>
+      </div>
+      <div class="post-show-favorited-container">
+        <% if @post.favorites.present? %>
+          <ul>
+            <%= render partial: "posts/users_who_favorited", collection: @post.favorites.order(created_at: :desc), as: "favorite" %>
+          </ul>
+        <% else %>
+          <p>まだお気に入りされていません。</p>
+        <% end %>
+      </div>
       <%= link_to "&lt; 投稿一覧に戻る".html_safe, posts_path, class: "button top-button posts-button" %>
     </div>
   </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -8,24 +8,9 @@
       <h2><%= @post.title %></h2>
       <div class="title-footer">
         <div class="button-under-title">
-          <% if user_signed_in? %>
-            <% if current_user.already_favorited?(@post) %>
-              <%= link_to post_favorite_path(@post, @post), method: :delete, class: "bookmark-button hover-opacity" do %>
-                <i class="fas fa-bookmark font-awesome-size-105"></i>
-                <%= @post.favorites.count %>件
-              <% end %>
-            <% else %>
-              <%= link_to post_favorites_path(@post), method: :post, class: "bookmark-button hover-opacity" do %>
-                <i class="far fa-bookmark font-awesome-size-105"></i>
-                <%= @post.favorites.count %>件
-              <% end %>
-            <% end %>
-          <% else %>
-            <%= link_to post_favorites_path(@post), method: :post, class: "bookmark-button hover-opacity" do %>
-              <i class="far fa-bookmark font-awesome-size-105"></i>
-              <%= @post.favorites.count %>件
-            <% end %>
-          <% end %>
+          <div class="favorite_button_<%= @post.id %>">
+            <%= render "favorites/favorite", post: @post %>
+          </div>
         </div>
         <% if @post.user == current_user %>
           <div class="button-under-title">
@@ -214,33 +199,12 @@
       </div>
       <div class="post-show-favorited">
         <h3>お気に入りしたユーザー</h3>
-        <% if user_signed_in? %>
-          <% if current_user.already_favorited?(@post) %>
-            <%= link_to post_favorite_path(@post), method: :delete, class: "bookmark-button hover-opacity" do %>
-              <i class="fas fa-bookmark font-awesome-size-105"></i>
-              <%= @post.favorites.count %>件
-            <% end %>
-          <% else %>
-            <%= link_to post_favorites_path(@post), method: :post, class: "bookmark-button hover-opacity" do %>
-              <i class="far fa-bookmark font-awesome-size-105"></i>
-              <%= @post.favorites.count %>件
-            <% end %>
-          <% end %>
-        <% else %>
-          <%= link_to post_favorites_path(@post), method: :post, class: "bookmark-button hover-opacity" do %>
-            <i class="far fa-bookmark font-awesome-size-105"></i>
-            <%= @post.favorites.count %>件
-          <% end %>
-        <% end %>
+        <div class="favorite_button_<%= @post.id %>">
+          <%= render "favorites/favorite", post: @post %>
+        </div>
       </div>
       <div class="post-show-favorited-container">
-        <% if @post.favorites.present? %>
-          <ul>
-            <%= render partial: "posts/users_who_favorited", collection: @post.favorites.order(created_at: :desc), as: "favorite" %>
-          </ul>
-        <% else %>
-          <p>まだお気に入りされていません。</p>
-        <% end %>
+        <%= render "posts/users_who_favorited", post: @post %>
       </div>
       <%= link_to "&lt; 投稿一覧に戻る".html_safe, posts_path, class: "button top-button posts-button" %>
     </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -8,9 +8,23 @@
       <h2><%= @post.title %></h2>
       <div class="title-footer">
         <div class="button-under-title">
-          <%= link_to "#", class: "bookmark-button hover-opacity" do %>
-            <i class="far fa-bookmark font-awesome-size-105"></i>
-            #件
+          <% if user_signed_in? %>
+            <% if current_user.already_favorited?(@post) %>
+              <%= link_to post_favorite_path(@post, @post), method: :delete, class: "bookmark-button hover-opacity" do %>
+                <i class="fas fa-bookmark font-awesome-size-105"></i>
+                <%= @post.favorites.count %>件
+              <% end %>
+            <% else %>
+              <%= link_to post_favorites_path(@post), method: :post, class: "bookmark-button hover-opacity" do %>
+                <i class="far fa-bookmark font-awesome-size-105"></i>
+                <%= @post.favorites.count %>件
+              <% end %>
+            <% end %>
+          <% else %>
+            <%= link_to post_favorites_path(@post), method: :post, class: "bookmark-button hover-opacity" do %>
+              <i class="far fa-bookmark font-awesome-size-105"></i>
+              <%= @post.favorites.count %>件
+            <% end %>
           <% end %>
         </div>
         <% if @post.user == current_user %>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -15,7 +15,14 @@
         <div class="user-achievements">
           <ul>
             <li>投稿数 <%= user.posts.count %></li>
-            <li>被お気に入り数 #</li>
+            <li>
+              被お気に入り数
+              <% sum = 0 %>
+              <% user.posts.each do |post| %>
+                <% sum += post.favorites.count %>
+              <% end %>
+              <%= sum %>
+            </li>
           </ul>
         </div>
         <div class="user-achievements">

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -16,12 +16,11 @@
           <ul>
             <li>投稿数 <%= user.posts.count %></li>
             <li>
-              被お気に入り数
               <% sum = 0 %>
               <% user.posts.each do |post| %>
                 <% sum += post.favorites.count %>
               <% end %>
-              <%= sum %>
+              被お気に入り数 <%= sum %>
             </li>
           </ul>
         </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -57,22 +57,43 @@
     </div>
   </div>
   <div class="main">
+    <div class="toggle-radio">
+      <%= radio_button_tag "toggle", "posts", checked: "checked" %>
+      <%= label_tag "toggle_posts", "投稿" %>
+      <%= radio_button_tag "toggle", "favorites" %>
+      <%= label_tag "toggle_favorites", "お気に入り" %>
+    </div>
     <div class="main-container">
-      <h3 class="main-container-h3"><%= @user.name %>の投稿</h3>
-      <div class="posts">
-        <% if @user.posts.present? %>
-          <%= render partial: "posts/post", collection: @user.posts, as: "post" %>
-        <% else %>
-          <div class="no-post-message">
-            <p>まだ投稿はありません。</p>
-            <% if @user === current_user %>
-              <%= link_to "＋投稿する", new_post_path, class: "to-new-post-button hover-transform" %>
-            <% end %>
-          </div>
-        <% end %>
+      <div class="toggle toggle-posts">
+        <h3 class="main-container-h3"><%= @user.name %>の投稿</h3>
+        <div class="posts">
+          <% if @user.posts.present? %>
+            <%= render partial: "posts/post", collection: @user.posts, as: "post" %>
+          <% else %>
+            <div class="no-post-message">
+              <p>まだ投稿はありません。</p>
+              <% if @user === current_user %>
+                <%= link_to "＋投稿する", new_post_path, class: "to-new-post-button hover-transform" %>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+      <div class="toggle toggle-favorites">
+        <h3 class="main-container-h3"><%= @user.name %>のお気に入り</h3>
+        <div class="posts">
+          <% if @user.favorites.present? %>
+            <%= render partial: "posts/favorited_post", collection: @user.favorites.order(created_at: :desc), as: "favorite" %>
+          <% else %>
+            <div class="no-post-message">
+              <p>まだお気に入りはありません。</p>
+            </div>
+          <% end %>
+        </div>
       </div>
       <%= link_to "&lt; ユーザー一覧に戻る".html_safe, list_users_path, class: "button top-button posts-button" %>
     </div>
   </div>
 </div>
 <%= link_to "＋投稿する", new_post_path, class: "fixed_to_post_link" %>
+<%= javascript_pack_tag 'users/toggle' %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -34,7 +34,11 @@
           <li>
             被お気に入り数<br>
             <span class="font-weight-bold">
-              #
+              <% sum = 0 %>
+              <% @user.posts.each do |post| %>
+                <% sum += post.favorites.count %>
+              <% end %>
+              <%= sum %>
             </span>
           </li>
           <div class="vertical-border"></div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
     collection do
       get "search"
     end
+    resources :favorites, only: [:create, :destroy]
   end
   devise_for :users, controllers: {
     sessions: "users/sessions",
@@ -19,5 +20,5 @@ Rails.application.routes.draw do
     end
   end
   resources :gear_powers, only: [:index, :show]
-  root :to => "home#top"
+  root "home#top"
 end

--- a/db/migrate/20221115235952_create_favorites.rb
+++ b/db/migrate/20221115235952_create_favorites.rb
@@ -1,0 +1,10 @@
+class CreateFavorites < ActiveRecord::Migration[6.1]
+  def change
+    create_table :favorites do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :post, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_06_095550) do
+ActiveRecord::Schema.define(version: 2022_11_15_235952) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -38,6 +38,15 @@ ActiveRecord::Schema.define(version: 2022_11_06_095550) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "favorites", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "post_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["post_id"], name: "index_favorites_on_post_id"
+    t.index ["user_id"], name: "index_favorites_on_user_id"
   end
 
   create_table "gear_powers", force: :cascade do |t|
@@ -96,5 +105,7 @@ ActiveRecord::Schema.define(version: 2022_11_06_095550) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "favorites", "posts"
+  add_foreign_key "favorites", "users"
   add_foreign_key "posts", "users"
 end

--- a/spec/factories/favorites.rb
+++ b/spec/factories/favorites.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :favorite do
+    user { post.user }
+    post
+  end
+end

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -12,8 +12,9 @@ RSpec.describe "Posts", type: :request do
   end
 
   describe "GET /index" do
-    let!(:post1) { create(:post, weapon: "わかばシューター", battle: "ガチヤグラ") }
+    let(:post1) { create(:post, weapon: "わかばシューター", battle: "ガチヤグラ") }
     let!(:post2) { create(:post, weapon: "スプラシューター", battle: "ナワバリバトル") }
+    let!(:favorite) { create(:favorite, user: post1.user, post: post1) }
 
     before do
       get posts_path
@@ -69,6 +70,11 @@ RSpec.describe "Posts", type: :request do
       expect(response.body).to include "gear_power_#{post2.shoes_sub1}.png"
       expect(response.body).to include "gear_power_#{post2.shoes_sub2}.png"
       expect(response.body).to include "gear_power_#{post2.shoes_sub3}.png"
+    end
+
+    it "お気に入り数を取得していること" do
+      expect(response.body).to include "0件"
+      expect(response.body).to include "1件"
     end
   end
 
@@ -148,6 +154,8 @@ RSpec.describe "Posts", type: :request do
     let!(:shoes_sub1) { GearPower.find(post.shoes_sub1) }
     let!(:shoes_sub2) { GearPower.find(post.shoes_sub2) }
     let!(:shoes_sub3) { GearPower.find(post.shoes_sub3) }
+    let(:user) { create(:user) }
+    let!(:favorite) { create(:favorite, user: user, post: post) }
 
     before do
       get post_path(post)
@@ -219,6 +227,14 @@ RSpec.describe "Posts", type: :request do
 
     it "コメントを取得していること" do
       expect(response.body).to include post.comment
+    end
+
+    it "お気に入り数を取得していること" do
+      expect(response.body).to include "1件"
+    end
+
+    it "お気に入りしたユーザーを取得していること" do
+      expect(response.body).to include user.name
     end
   end
 

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -2,8 +2,10 @@ require 'rails_helper'
 
 RSpec.describe "Users", type: :request do
   describe "GET /list" do
-    let!(:user1) { create(:user, prowess: "A+") }
-    let!(:user2) { create(:user, prowess: "B-") }
+    let(:user1) { create(:user, prowess: "A+") }
+    let(:user2) { create(:user, prowess: "B-") }
+    let(:post) { create(:post, weapon: "わかばシューター", battle: "ガチヤグラ", user: user1) }
+    let!(:favorite) { create(:favorite, user: user2, post: post) }
 
     before do
       get list_users_path
@@ -21,7 +23,8 @@ RSpec.describe "Users", type: :request do
     it "ユーザーの各情報を取得していること" do
       expect(response.body).to include user1.rank.to_s
       expect(response.body).to include user1.prowess
-      expect(response.body).to include user1.posts.count.to_s
+      expect(response.body).to include "投稿数 1"
+      expect(response.body).to include "被お気に入り数 1"
     end
 
     it "ユーザーのアイコン画像を取得していること" do
@@ -30,8 +33,10 @@ RSpec.describe "Users", type: :request do
   end
 
   describe "GET /search" do
-    let!(:user1) { create(:user, prowess: "A+") }
-    let!(:user2) { create(:user, prowess: "B-") }
+    let(:user1) { create(:user, prowess: "A+") }
+    let(:user2) { create(:user, prowess: "B-") }
+    let(:post) { create(:post, weapon: "わかばシューター", battle: "ガチヤグラ", user: user1) }
+    let!(:favorite) { create(:favorite, user: user2, post: post) }
 
     before do
       get search_users_path
@@ -49,7 +54,8 @@ RSpec.describe "Users", type: :request do
     it "ユーザーの各情報を取得していること" do
       expect(response.body).to include user1.rank.to_s
       expect(response.body).to include user1.prowess
-      expect(response.body).to include user1.posts.count.to_s
+      expect(response.body).to include "投稿数 1"
+      expect(response.body).to include "被お気に入り数 1"
     end
 
     it "ユーザーのアイコン画像を取得していること" do
@@ -59,8 +65,11 @@ RSpec.describe "Users", type: :request do
 
   describe "GET /show" do
     let(:user) { create(:user, prowess: "A+") }
-    let!(:post1) { create(:post, weapon: "わかばシューター", battle: "ガチヤグラ", user: user) }
+    let(:post1) { create(:post, weapon: "わかばシューター", battle: "ガチヤグラ", user: user) }
     let!(:post2) { create(:post, weapon: "わかばシューター", battle: "ガチヤグラ", user: user) }
+    let(:post3) { create(:post, weapon: "わかばシューター", battle: "ガチヤグラ") }
+    let!(:favorite1) { create(:favorite, user: post3.user, post: post1) }
+    let!(:favorite2) { create(:favorite, user: user, post: post3) }
 
     before do
       sign_in user
@@ -80,12 +89,15 @@ RSpec.describe "Users", type: :request do
       expect(response.body).to include user.rank.to_s
       expect(response.body).to include user.prowess
       expect(response.body).to include user.profile
-      expect(response.body).to include user.posts.count.to_s
     end
 
-    it "これまでの投稿を取得していること" do
+    it "自身の投稿を取得していること" do
       expect(response.body).to include post1.title
       expect(response.body).to include post2.title
+    end
+
+    it "自身がお気に入りした投稿を取得していること" do
+      expect(response.body).to include post3.title
     end
 
     it "ユーザーのアイコン画像を取得していること" do


### PR DESCRIPTION
### 概要
投稿に対して、お気に入りできる機能の作成を行う。
お気に入りに関する情報（Favorite）は、favoritesテーブルを作成し、管理する。
またお気に入りボタンでは、ajaxによって非同期通信を行うこととする。

### やったこと
・favoritesテーブルを作成し、お気に入りボタンを実装（実装箇所は以下の3箇所）
    └投稿一覧ページ
    └投稿詳細ページ
    └ユーザー詳細ページ
・お気に入りボタンの通信処理をajaxによって非同期通信化
・ユーザー一覧ページとユーザー詳細ページにて、仮置きしていた被お気に入り数を実装
・お気に入りに関するテストを、既存のrequest specファイルとsystem specファイルに追加

### 備考
・ajaxにてjqueryを扱うため、gemfileにjquery-railsを追加しています。