### PR TITLE
アクセス権限の修正

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -12,6 +12,8 @@ class FavoritesController < ApplicationController
     favorite.destroy
   end
 
+  private
+
   # ajax通信ではdeviseのauthenticate_user!が使えないため独自に定義
   def authenticate_user
     if current_user.nil?

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,7 @@
 class PostsController < ApplicationController
   before_action :authenticate_user!, { only: [:new, :create, :edit, :update, :destroy] }
   before_action :set_q, { only: [:search, :index] }
+  before_action :ensure_correct_user, { only: [:edit, :update] }
 
   def new
     @post = Post.new
@@ -92,5 +93,13 @@ class PostsController < ApplicationController
 
   def set_q
     @q = Post.ransack(params[:q])
+  end
+
+  def ensure_correct_user
+    @post = Post.find(params[:id])
+    if current_user.id != @post.user_id
+      flash[:alert] = "権限がありません。編集を行うには、投稿者としてログインする必要があります。"
+      redirect_to posts_path
+    end
   end
 end

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -782,6 +782,7 @@ RSpec.describe "Posts", type: :system do
   describe "#edit" do
     let(:post) { create(:post, weapon: "わかばシューター", battle: "ガチヤグラ") }
     let!(:gear_powers) { create_list(:gear_power1, 27) }
+    let(:guest_user) { create(:user, email: "guest@example.com") }
 
     context "まだログインしていない場合" do
       before do
@@ -797,7 +798,22 @@ RSpec.describe "Posts", type: :system do
       end
     end
 
-    context "すでにログインしている場合" do
+    context "非投稿者としてログインしている場合" do
+      before do
+        sign_in guest_user
+        visit edit_post_path(post)
+      end
+
+      it "投稿編集ページに遷移したら、編集権限がないため投稿一覧ページにリダイレクトすること" do
+        expect(current_path).to eq posts_path
+      end
+
+      it "リダイレクト後に正しいフラッシュを表示していること" do
+        expect(page).to have_content "権限がありません。編集を行うには、投稿者としてログインする必要があります。"
+      end
+    end
+
+    context "投稿者としてログインしている場合" do
       before do
         sign_in post.user
         visit edit_post_path(post)


### PR DESCRIPTION
### 概要
投稿の編集を投稿者以外も行える状態のため、投稿者のみ行えるように修正する。

### やったこと
・posts controllerに、メソッド`ensure_correct_user`を定義し、editアクションとupdateアクションへのアクセスを制限
・postsのsystem specに、投稿の編集を投稿者以外が行えないか検証するテストを追加

### 備考
・favorites controllerにprivateの付与漏れがあったため、本リポジトリで追加しています。